### PR TITLE
Add AppVeyor CI support

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,147 @@
+# .appveyor.yml
+
+# ref: <https://www.appveyor.com/docs/appveyor-yml>[`@`](https://archive.is/OUJHS)
+# * validation tool @ <https://ci.appveyor.com/tools/validate-yaml>
+
+# * note: AppVeyor setup
+# 1. add an AppVeyor project observing the repository
+# 2. enable "General / Skip branches without appveyor.yml" within the project SETTINGS
+# 3. verify correct CI_TESTING_EXTRA_MODULES
+# 4. (optional) add CODECOV_TOKEN and/or COVERALLS_TOKEN (from respective sites) as encrypted environment variables
+
+version: "{build} ~ {branch}"
+
+skip_tags: true     # do not build on tags
+
+branches:
+  except:
+    - gh-pages
+
+environment:
+    global:
+        CI_TESTING_EXTRA_MODULES: "Pod::Coverage::TrustPod Test::Perl::Critic"
+    matrix:
+        - Perl_VERSION: "latest"
+          COVERAGE: "Codecov Coveralls" ## note: case sensitive!
+        - Perl_VERSION: "5.24.3.1"
+        - Perl_VERSION: "5.22.3.1"
+        - Perl_VERSION: "5.20.3.3"
+        - Perl_VERSION: "5.16"
+        - Perl_VERSION: "5.14"
+        - Perl_VERSION: "5.12"
+        - Perl_VERSION: "5.10"
+        - Perl_VERSION: "5.8"
+        - Perl_VERSION: "5.8.8"
+
+# note: cache is too small to be helpful
+# cache:
+#     - C:\strawberry -> .appveyor.yml
+
+install:
+    # move "C:\mingw" to avoid cross library linking (a problem with older perl versions, breaking dll compilation with "/mingw/lib/dllcrt2.o:(.text+0xd1): undefined reference to `__dyn_tls_init_callback'")
+    # * only truly needed for modules containing XS compilation, but ok for all modules
+    - move c:\mingw c:\mingw.o >NUL
+    # ensure CWD is project main directory
+    - cd "%APPVEYOR_BUILD_FOLDER%"
+    # force branch checkout (if knowable), then reset to the specific commit ## (needed for accurate code coverage info)
+    # * this allows later apps to see the branch name using standard `git branch` operations, yet always builds the correct specific commit
+    # * ref: <https://github.com/appveyor/ci/issues/1606>[`@`](https://archive.is/RVpnF)
+    - if DEFINED APPVEYOR_REPO_BRANCH ( git checkout "%APPVEYOR_REPO_BRANCH%" & git reset --hard "%APPVEYOR_REPO_COMMIT%" )
+    # install perl
+    # * install strawberry perl
+    - call .appveyor_install-perl.BAT
+    # * show perl version verification
+    - perl -V
+    # * install `cpanm` (needed for older perl versions)
+    - cpan -T -i App::cpanminus 2>&1 | rem
+    # * pre-install problematic modules for perl versions < 5.14
+    #   'ExtUtils::MakeMaker'
+    #   - for perl versions < 5.14, installing ExtUtils::MakeMaker >= 7.0 causes ... "The system cannot find the path specified.\ndmake.exe:  Error code 129, while making 'blib\lib\ExtUtils\.exists'"
+    - perl -e "use version; use ExtUtils::MakeMaker; exit -1 if version->parse($ExtUtils::MakeMaker::VERSION) < version->parse(q{7.0});" || cpanm --no-interactive --no-man-pages --notest ExtUtils::MakeMaker~"< 7.0" 2>&1
+    #   'version'
+    #   - updated version needed for many installs; local VERSION file conflicts and confuses `cpanm` => using "//version" to disambiguate
+    #   - 'version' requires 'parent' (missing requirement on some 0.9915+ versions, specifically 0.9918 [most recent on 2018-01-20])
+    - cpanm --no-interactive --no-man-pages --notest --quiet parent //version 2>&1
+    #   'ExtUtils::ParseXS'
+    #   - updated ParseXS needed to install File::Spec (o/w PathTools installation fails with "Cwd.o:Cwd.c:(.text+0x593): undefined reference to `croak_xs_usage'")
+    - cpanm --no-interactive --no-man-pages --notest --quiet ExtUtils::ParseXS 2>&1
+    # #   'Win32'
+    # #   - updated Win32 needed to avoid "Use of inherited AUTOLOAD for non-method Win32::GetConsoleCP() is deprecated at C:/strawberry/perl/site/lib/ExtUtils/MakeMaker/Locale.pm line 50" in perl 5.12 (using Win32 0.44)
+    # - cpanm --no-interactive --no-man-pages --notest --quiet Win32 2>&1
+    # install baseline dependencies
+    - cpanm --no-interactive --no-man-pages --notest --quiet --skip-satisfied --installdeps .
+    # check OS_unsupported
+    - perl Build.PL 2>&1 | findstr /b /i /r "OS unsupported\b" >NUL 2>&1 && set "OS_unsupported=OS unsupported" || set "OS_unsupported="
+    # install any extra dependencies (including recommended dependencies)
+    - if NOT DEFINED OS_unsupported ( cpanm --no-interactive --no-man-pages --notest --quiet --skip-satisfied --with-recommends --installdeps . )
+    # * install extra dependencies for full CI testing
+    - if NOT DEFINED OS_unsupported if defined CI_TESTING_EXTRA_MODULES ( cpanm --no-interactive --no-man-pages --notest --quiet --skip-satisfied %CI_TESTING_EXTRA_MODULES% )
+    # check code coverage
+    - ps: |
+        if ($env:COVERAGE) {
+            # determine coverage support (signalled by <COVERAGE_TYPE>_TOKEN environment vars)
+            $s = $env:COVERAGE
+            $coverage = @()
+            $s.split() | foreach {
+                $name = "env:\"+$_.ToUpper()+"_TOKEN"
+                $val = (get-item $("env:\"+$_.ToUpper()+"_TOKEN") -ea ignore).value
+                # write-host "$name = '$val'"
+                # write-host "`$val.length = $($val.length)"
+                if ($val.length -gt 0) { $coverage += $_ } else { write-host -f yellow "info: skipping '$_' coverage (missing '$($_.ToUpper() + '_TOKEN')')" }
+                }
+            $env:COVERAGE = $coverage -join " "
+            # write-host "env:COVERAGE = $env:COVERAGE"
+            }
+    # install any needed code coverage dependencies
+    - ps: |
+        if (-not $env:OS_unsupported -and $env:COVERAGE) {
+            # install coverage support
+            cpanm --no-interactive --no-man-pages --notest --skip-satisfied Devel::Cover
+            ($env:COVERAGE).split() | foreach {
+                # echo "cpanm --no-interactive --no-man-pages --notest --skip-satisfied Devel::Cover::Report::$_"
+                if ( $_ -ieq "Coveralls" ) {
+                    ## override for bugged default "Coveralls"; use patched version from personal github repo
+                    cpanm --no-interactive --no-man-pages --notest --quiet --skip-satisfied https://github.com/rivy/perl.Devel-Cover-Report-Coveralls.git
+                    }
+                else {
+                    cpanm --no-interactive --no-man-pages --notest --quiet --skip-satisfied Devel::Cover::Report::$_
+                    }
+                }
+            }
+
+before_build:
+    # ensure CWD is project main directory
+    - cd "%APPVEYOR_BUILD_FOLDER%"
+    # setup environment options
+    - set AUTOMATED_TESTING=1
+    - set DEVEL_COVER_OPTIONS=-ignore,^_build/
+    # * for non-COVERAGE builds, enable parallel processing (COVERAGE builds need sequential, correctly interleaved, output to avoid warnings)
+    - if NOT DEFINED COVERAGE (set "HARNESS_OPTIONS=j")
+    - set HARNESS_TIMER=1
+    # * for COVERAGE builds, preload JSON:PP to avoid JSON::PP::Boolean redefine warning (see <https://github.com/rurban/Cpanel-JSON-XS/issues/65#issuecomment-219352754>)
+    - if DEFINED COVERAGE (set HARNESS_PERL_SWITCHES=-MJSON::PP %HARNESS_PERL_SWITCHES%)
+    # display environment
+    - echo AUTOMATED_TESTING=%AUTOMATED_TESTING%
+    - echo CI_TESTING_EXTRA_MODULES=%CI_TESTING_EXTRA_MODULES%
+    - echo COVERAGE=%COVERAGE%
+    - echo DEVEL_COVER_OPTIONS=%DEVEL_COVER_OPTIONS%
+    - echo HARNESS_OPTIONS=%HARNESS_OPTIONS%
+    - echo HARNESS_TIMER=%HARNESS_TIMER%
+    - echo HARNESS_PERL_SWITCHES=%HARNESS_PERL_SWITCHES%
+    - echo make=%make%
+    - echo OS_unsupported=%OS_unsupported%
+    # - echo PATH=%PATH%
+    - echo PERL5OPT=%PERL5OPT%
+
+build_script:
+    - if NOT DEFINED OS_unsupported ( perl Build.PL && perl Build )
+
+test_script:
+    - if NOT DEFINED OS_unsupported if DEFINED COVERAGE ( perl Build testcover ) else ( perl Build test )
+
+after_test:
+    # reporting
+    # * report any code coverage information
+    - ps: if (-not $env:OS_unsupported -and $env:COVERAGE) { $env:COVERAGE.split() | foreach { cover -report $_ 2>&1 } }
+    - ps: |
+        if ($env:OS_unsupported) { write-host -f magenta "WARN: OS unsupported" }

--- a/.appveyor_install-perl.BAT
+++ b/.appveyor_install-perl.BAT
@@ -1,0 +1,50 @@
+@echo off
+set "ERRORLEVEL="
+
+:: NOTE: contains some peculiar statement ordering and redirections b/c of AppVeyor bugs when executing BAT/CMD scripts
+
+if not defined perl_version ( set "perl_version=latest" )
+
+:: ## refine "generic" perl versions
+if "%perl_version%"=="5.8"   ( set "perl_version=5.8.9" )
+if "%perl_version%"=="5.10"  ( set "perl_version=5.10.1" )
+if "%perl_version%"=="5.12"  ( set "perl_version=5.12.1" )
+if "%perl_version%"=="5.14"  ( set "perl_version=5.14.4" )
+if "%perl_version%"=="5.16"  ( set "perl_version=5.16.3" )
+if "%perl_version%"=="5.18"  ( set "perl_version=5.18.4" )
+
+:: ## determine download file (as needed [only for certain earlier perl versions])
+set "perl_download="
+if "%perl_version%"=="5.8.8"  ( set "perl_download=http://strawberryperl.com/download/5.8.8/strawberry-perl-5.8.8.4.zip" )
+if "%perl_version%"=="5.8.9"  ( set "perl_download=http://strawberryperl.com/download/5.8.9/strawberry-perl-5.8.9.5.zip" )
+if "%perl_version%"=="5.10.1" ( set "perl_download=http://strawberryperl.com/download/5.10.1.1/strawberry-perl-5.10.1.1.zip" )
+if "%perl_version%"=="5.12.1" ( set "perl_download=http://strawberryperl.com/download/5.12.1.0/strawberry-perl-5.12.1.0.zip" )
+if "%perl_version%"=="5.14.4" ( set "perl_download=http://strawberryperl.com/download/5.14.4.1/strawberry-perl-5.14.4.1-64bit.zip" )
+if "%perl_version%"=="5.16.3" ( set "perl_download=http://strawberryperl.com/download/5.16.3.1/strawberry-perl-5.16.3.1-64bit.zip" )
+if "%perl_version%"=="5.18.4" ( set "perl_download=http://strawberryperl.com/download/5.18.4.1/strawberry-perl-5.18.4.1-64bit.zip" )
+
+:: ## install
+echo|set /p OUTPUT="Installing Strawberry Perl "
+
+set "cinst_options=--yes"
+if /i not "%perl_version%" == "latest" ( set "cinst_options=%cinst_options% --version %perl_version%" )
+
+if not defined perl_download (
+  echo|set /p OUTPUT="(%perl_version%; via Chocolatey ['cinst %cinst_options% StrawberryPerl']) ... "
+  cinst %cinst_options% StrawberryPerl | rem # script fails here if STDOUT redirected to NUL [AppVeyor bug]
+) else (
+  echo|set /p OUTPUT="(%perl_version%; via direct download) ... "
+    curl -# -L "%perl_download%" -o c:\strawberryperl.zip >NUL 2>&1 && 7z -bd x c:\strawberryperl.zip -oc:\strawberry >NUL
+    )
+)
+
+if "%ERRORLEVEL%" == "0" ( echo done ) else ( echo FAILED [ERRORLEVEL=%ERRORLEVEL%] & exit /b -1 )
+
+:: ## configure
+echo|set /p OUTPUT="Configuring Perl ... "
+
+set "PATH=C:\strawberry\c\bin;C:\strawberry\perl\site\bin;C:\strawberry\perl\bin;%PATH%"
+
+for /f "usebackq delims=" %%d in (`perl -MConfig -e"print $Config{make}"`) do set make=%%d
+
+echo done

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.{bat,[bB][aA][tT]}    text eol=crlf
+*.{cmd,[cC][mM][dD]}    text eol=crlf

--- a/t/listmatch-gitignore.t
+++ b/t/listmatch-gitignore.t
@@ -1,4 +1,4 @@
-# Copyright (C) 2016-2017 Guido Flohr <guido.flohr@cantanea.com>, 
+# Copyright (C) 2016-2017 Guido Flohr <guido.flohr@cantanea.com>,
 # all rights reserved.
 
 # This file is distributed under the same terms and conditions as
@@ -34,4 +34,5 @@ unshift @INC, $libdir;
 
 $ENV{FILE_GLOBSTAR_GIT_CHECK_IGNORE} = 1;
 
+use lib q/./;
 require "t/listmatch-xmode.t";

--- a/t/listmatch-gitignore.t
+++ b/t/listmatch-gitignore.t
@@ -10,16 +10,10 @@ use Cwd;
 use File::Spec;
 
 BEGIN {
-    my ($volume, $directory) = File::Spec->splitpath(Cwd::abs_path($0));
-    my $here = File::Spec->catpath($volume, $directory);
-    my $gitdir = File::Spec->catdir($here, File::Spec->updir, '.git');
-
-    $ENV{AUTHOR_TESTING} = 1 if -d $gitdir;
-
-    unless ($ENV{AUTHOR_TESTING}) {
-        print qq{1..0 # SKIP these tests are for testing by the author\n};
-        exit
-    }
+  unless ($ENV{AUTHOR_TESTING}) {
+    print qq{1..0 # SKIP these tests are for testing by the author\n};
+    exit
+  }
 }
 
 # We run all the tests from listmatch-xmode.t but with a


### PR DESCRIPTION
* adds support for [AppVeyor CI](https://ci.appveyor.com/project/rivy/perl-file-globstar) (will need short setup on your AppVeyor account)
  * testing back to perl v5.8.8
* also includes support for [CodeCov](https://codecov.io/gh/rivy/perl.File-Globstar/branches) and [Coveralls](https://coveralls.io/github/rivy/perl.File-Globstar) (optional; will need some minor extra setup on your AppVeyor account)