### PR TITLE
disable unneeded AUTHOR and RELEASE testing in AppVeyor CI

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -24,8 +24,8 @@ environment:
   matrix:
     - Perl_VERSION: "latest"
       COVERAGE: "Codecov Coveralls" ## note: case sensitive!
-      AUTHOR_TESTING: 1
-      RELEASE_TESTING: 1
+    #   AUTHOR_TESTING: 1
+    #   RELEASE_TESTING: 1
     - Perl_VERSION: "5.28"
     - Perl_VERSION: "5.26"
     - Perl_VERSION: "5.24"


### PR DESCRIPTION
With this change, the first AppVeyor CI job runs to completion and code coverage information is pushed to CodeCov ([rivy/perl.File-Globstar](https://codecov.io/gh/rivy/perl.File-Globstar)) and Coveralls ([rivy/perl.File-Globstar](https://coveralls.io/github/rivy/perl.File-Globstar)). You'll need to [set up the tokens](https://github.com/rivy/CI.AppVeyor.helpers-perl#code-coverage) on your side if you'd like to keep coverage updated with each commit.